### PR TITLE
Add live menu sweep and lounge social network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Watson Discovery / Assistant credentials
+WATSON_API_KEY=changeme
+WATSON_SERVICE_URL=https://api.us-south.assistant.watson.cloud.ibm.com
+
+# MongoDB Atlas connection string
+db_uri=mongodb+srv://username:password@cluster.mongodb.net/budsense
+
+# POS API tokens
+POS_API_KEY=changeme
+
+# Live menu aggregator
+DISPENSARY_MENU_API_KEY=changeme
+MENU_SYNC_RADIUS_MILES=60
+
+# Notification providers
+TWILIO_ACCOUNT_SID=changeme
+TWILIO_AUTH_TOKEN=changeme
+SENDGRID_API_KEY=changeme
+
+# Social refresh cadence
+SOCIAL_REFRESH_SCHEDULE=0 9 * * *
+
+# Analytics
+FIREBASE_API_KEY=changeme
+MIXPANEL_TOKEN=changeme

--- a/README.md
+++ b/README.md
@@ -1,2 +1,100 @@
-# AI.Agentic.Evolution
-Agents dedicated to constantly improving my life and the environment
+# BudSense.AI Prototype
+
+BudSense.AI is the intelligent budtender platform that blends Watson-powered strain knowledge, Certificate of Analysis (COA) guardrails, and automated reservations so every lounge guest gets clean, verified cannabis experiences. This repository ships a runnable prototype with a FastAPI backend, a Tailwind/React front-end demo, an automation flow for n8n, and brand collateral.
+
+## Repository Layout
+
+```
+.
+├── assets/
+│   └── poster.svg              # Retro-futuristic marketing poster concept
+├── backend/
+│   ├── app.py                  # FastAPI application with prototype endpoints
+│   └── requirements.txt        # Python dependencies for the backend
+├── frontend/
+│   └── index.html              # Standalone React + Tailwind chatbot experience
+├── n8n/
+│   └── flows/
+│       └── auto_order.json     # Webhook → reserve → notify automation skeleton
+├── .env.example                # Sample environment variables
+└── README.md
+```
+
+## Features Preview
+
+- **Strain Knowledge Engine** – `/strains/search` surfaces mock strains with terpenes, effects, COA badges, and lab report links. Swap in Watson Discovery + MongoDB Atlas to go live.
+- **COA Guard** – `/ingest_coa` ingests analytes and flags any values above their limits so you can block contaminated batches.
+- **Auto-Reserve Flow** – `/orders/reserve` mocks a POS hold with lounge-friendly responses, while `/notify` simulates fan-out through SMS, email, or voice.
+- **Live Menu Sweep** – `/menus/nearby` and `/menus/sync` download every live dispensary menu within a 60 mile radius, ready for lounge routing and deal stacking.
+- **Deal Engine & Connections** – `/lounge/deals/apply` augments menu items with the best promos while surfacing nearby lounge buddies who share your vibe.
+- **Cannabis Social Graph** – `/social/feed`, `/social/posts`, `/social/buddies/match`, and `/social/daily-refresh` power a Facebook-style feed for flower drops, current smoke check-ins, and lounge meetups.
+- **Funky Budtender UI** – The React demo speaks like a pro budtender, animates reserves with GSAP, and showcases lounge and automation callouts.
+- **n8n Automation** – `auto_order.json` wires a webhook into the reserve endpoint and dispatches Twilio + email confirmations.
+- **Branding Assets** – `assets/poster.svg` delivers a psychedelic, resale-ready poster for decks and kiosks.
+
+## Getting Started
+
+### Backend API
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn app:app --reload --port 8000
+```
+
+- Health check: `GET http://localhost:8000/health`
+- Strain search: `GET http://localhost:8000/strains/search?q=gelato`
+- COA ingest (example payload):
+  ```bash
+  curl -X POST http://localhost:8000/ingest_coa \
+       -H "Content-Type: application/json" \
+       -d '{
+         "strain_name": "Gelato 41",
+         "lab_name": "SC Labs",
+         "source_url": "https://labs.example.com/gelato41.pdf",
+         "collected_at": "2024-01-12T12:00:00Z",
+         "analytes": [
+           {"name": "Pesticide XYZ", "value_ppm": 0.4, "limit_ppm": 0.2},
+           {"name": "Heavy Metal ABC", "value_ppm": 0.05, "limit_ppm": 0.2}
+         ]
+       }'
+  ```
+
+### Frontend Demo
+
+1. Start the backend (above) or change `window.BUDSENSE_API_BASE` inside `frontend/index.html` to an accessible endpoint.
+2. Open `frontend/index.html` in a modern browser.
+3. Ask for strains like “Gelato 41” or “creative sativa limonene”, then trigger the reserve flow to see the mock reservation response.
+4. Explore the **Live Menus** column to sync every dispensary within 60 miles, apply lounge deals, and surface terp-aligned connections.
+5. Jump into the **Lounge Buddies Social** feed to refresh daily drops, browse profiles, and match with smoking partners who share your favorites.
+
+### n8n Flow
+
+1. Import `n8n/flows/auto_order.json` into your n8n instance.
+2. Configure credentials for your POS, Twilio, and email provider in n8n.
+3. Point the webhook to your deployed API to auto-reserve and notify guests.
+
+### Environment Variables
+
+Duplicate `.env.example` into `.env` and populate credentials for Watson Discovery/Assistant, MongoDB Atlas, POS vendors, notification providers, live menu aggregators, and social refresh jobs before production deployment.
+
+Key additions for the menu + social expansion:
+
+- `DISPENSARY_MENU_API_KEY` – credential for the partner feed (Leafly, Weedmaps, Dutchie, etc.).
+- `MENU_SYNC_RADIUS_MILES` – default sweep radius for menu pulls (prototype uses 60 miles).
+- `SOCIAL_REFRESH_SCHEDULE` – cron or ISO8601 schedule for daily social refreshes.
+
+## Roadmap Highlights
+
+- Wire Watson Discovery + LangChain for nightly strain ingestion and summarization.
+- Expand COA parser with LLM-assisted PDF extraction and analyte confidence scoring.
+- Implement tenant-aware POS drivers (Treez, Dutchie, Meadow, Blaze) with audit trails.
+- Layer in Stripe billing, loyalty analytics, and kiosk/white-label theming.
+- Plug dispensary menu aggregator APIs directly into `/menus/sync` for real-time availability.
+- Add real push notifications + friend graph storage for the lounge buddies network.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/assets/poster.svg
+++ b/assets/poster.svg
@@ -1,0 +1,55 @@
+<svg width="1080" height="1350" viewBox="0 0 1080 1350" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1080" y2="1350" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0B1220" />
+      <stop offset="1" stop-color="#1B1D3A" />
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(540 420) rotate(90) scale(480 520)">
+      <stop stop-color="#6B21A8" stop-opacity="0.8" />
+      <stop offset="1" stop-color="#0B1220" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1080" height="1350" fill="url(#bg)" />
+  <rect width="1080" height="1350" fill="url(#glow)" />
+  <text x="120" y="200" fill="#FF6F00" font-family="'Space Grotesk', sans-serif" font-size="36" letter-spacing="0.35em">B U D S E N S E . A I</text>
+  <text x="120" y="320" fill="#F9FAFB" font-family="'Space Grotesk', sans-serif" font-size="92" font-weight="700" letter-spacing="0.04em">
+    THE INTELLIGENT
+  </text>
+  <text x="120" y="420" fill="#A855F7" font-family="'Space Grotesk', sans-serif" font-size="92" font-weight="700" letter-spacing="0.04em">
+    BUDTENDER
+  </text>
+  <text x="120" y="520" fill="#F9FAFB" opacity="0.75" font-family="'Space Grotesk', sans-serif" font-size="30" letter-spacing="0.06em">
+    WATSON-POWERED RECOMMENDATIONS. CLEAN PRODUCT GUARANTEED.
+  </text>
+  <circle cx="880" cy="1080" r="190" fill="#FF6F00" fill-opacity="0.15" />
+  <circle cx="880" cy="1080" r="130" fill="#FF6F00" fill-opacity="0.25" />
+  <circle cx="880" cy="1080" r="70" fill="#FF6F00" />
+  <text x="150" y="660" fill="#F9FAFB" font-family="'Space Grotesk', sans-serif" font-size="32" font-weight="600">
+    ➤ Watson Discovery + LangChain
+  </text>
+  <text x="150" y="720" fill="#F9FAFB" font-family="'Space Grotesk', sans-serif" font-size="32" font-weight="600">
+    ➤ COA Guardrails with impurity badges
+  </text>
+  <text x="150" y="780" fill="#F9FAFB" font-family="'Space Grotesk', sans-serif" font-size="32" font-weight="600">
+    ➤ POS auto-reserve + lounge routing
+  </text>
+  <text x="150" y="840" fill="#F9FAFB" font-family="'Space Grotesk', sans-serif" font-size="32" font-weight="600">
+    ➤ Retro-futuristic chatbot personality
+  </text>
+  <rect x="120" y="960" width="520" height="220" rx="32" fill="#111827" stroke="#FF6F00" stroke-width="3" stroke-dasharray="16 16" />
+  <text x="160" y="1030" fill="#F9FAFB" font-family="'Space Grotesk', sans-serif" font-size="28" font-weight="600">
+    SaaS Tiers
+  </text>
+  <text x="160" y="1090" fill="#F9FAFB" font-family="'Space Grotesk', sans-serif" font-size="24">
+    • Free: boutique chat + strain intel
+  </text>
+  <text x="160" y="1140" fill="#F9FAFB" font-family="'Space Grotesk', sans-serif" font-size="24">
+    • Pro: auto-order, COA parsing, notifications
+  </text>
+  <text x="160" y="1190" fill="#F9FAFB" font-family="'Space Grotesk', sans-serif" font-size="24">
+    • Enterprise: lounge integration + analytics
+  </text>
+  <text x="120" y="1280" fill="#F1F5F9" font-family="'Space Grotesk', sans-serif" font-size="24" letter-spacing="0.2em">
+    CLEAN FLOWER. CURATED EXPERIENCES. LOYAL CUSTOMERS.
+  </text>
+</svg>

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,755 @@
+"""BudSense.AI prototype FastAPI application."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+
+app = FastAPI(
+    title="BudSense.AI Prototype API",
+    description=(
+        "Prototype endpoints for the BudSense.AI intelligent budtender platform."
+    ),
+    version="0.1.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class Strain(BaseModel):
+    name: str
+    genetics: str
+    dominant_terpenes: List[str] = Field(default_factory=list)
+    effects: List[str] = Field(default_factory=list)
+    thc_percent: float = Field(..., ge=0)
+    cbd_percent: float = Field(..., ge=0)
+    aroma: List[str] = Field(default_factory=list)
+    clean_badge: bool = False
+    last_verified: datetime
+    lab_report_url: Optional[str]
+    notes: Optional[str]
+
+
+class StrainSearchResponse(BaseModel):
+    query: str
+    results: List[Strain]
+
+
+class COAAnalyte(BaseModel):
+    name: str
+    value_ppm: float
+    limit_ppm: float
+
+    @property
+    def is_flagged(self) -> bool:
+        return self.value_ppm > self.limit_ppm
+
+
+class COAIngestRequest(BaseModel):
+    strain_name: str
+    lab_name: str
+    source_url: str
+    collected_at: datetime
+    analytes: List[COAAnalyte] = Field(default_factory=list)
+
+
+class COAIngestResponse(BaseModel):
+    strain_name: str
+    lab_name: str
+    source_url: str
+    flagged_analytes: List[str] = Field(default_factory=list)
+    clean: bool
+    ingested_at: datetime
+
+
+class ReserveItem(BaseModel):
+    product_id: str
+    quantity: float = Field(gt=0)
+    unit: str = "g"
+
+
+class ReserveRequest(BaseModel):
+    tenant_id: str = Field(..., alias="tenantId")
+    customer_name: str
+    contact_method: str
+    contact_value: str
+    pickup_preference: str = Field(default="in-store")
+    items: List[ReserveItem]
+
+
+class ReserveResponse(BaseModel):
+    reservation_id: str
+    status: str
+    message: str
+
+
+class NotificationRequest(BaseModel):
+    channel: str
+    recipient: str
+    message: str
+    metadata: Optional[dict] = None
+
+
+class NotificationResponse(BaseModel):
+    status: str
+    detail: str
+
+
+class GeoPoint(BaseModel):
+    lat: float = Field(..., ge=-90, le=90)
+    lon: float = Field(..., ge=-180, le=180)
+
+
+class MenuItem(BaseModel):
+    sku: str
+    name: str
+    category: str
+    thc_percent: float
+    cbd_percent: float
+    price: float
+    unit: str = "g"
+    deal: Optional[str] = None
+    in_stock: bool = True
+    tags: List[str] = Field(default_factory=list)
+
+
+class DispensaryMenu(BaseModel):
+    dispensary_id: str
+    dispensary_name: str
+    distance_miles: float
+    last_synced: datetime
+    items: List[MenuItem]
+    loyalty_deals: List[str] = Field(default_factory=list)
+    lounge_ready: bool = False
+
+
+class MenuSyncRequest(BaseModel):
+    location: GeoPoint
+    radius_miles: float = Field(default=60, gt=0, le=120)
+    categories: List[str] = Field(default_factory=list)
+
+
+class MenuSyncResponse(BaseModel):
+    synced_at: datetime
+    radius_miles: float
+    menus: List[DispensaryMenu]
+
+
+class DealApplicationRequest(BaseModel):
+    dispensary_id: str
+    vibe: Optional[str] = None
+    prefer_clean: bool = True
+    favorite_terpenes: List[str] = Field(default_factory=list)
+
+
+class DealApplicationResponse(BaseModel):
+    dispensary_id: str
+    applied_items: List[MenuItem]
+    connection_notes: List[str]
+    lounge_recommendations: List[str]
+
+
+class SocialProfile(BaseModel):
+    profile_id: str
+    display_name: str
+    favorite_strains: List[str]
+    current_smoke: Optional[str] = None
+    lounge_homebase: Optional[str] = None
+    vibes: List[str] = Field(default_factory=list)
+    bio: Optional[str] = None
+
+
+class SocialPost(BaseModel):
+    post_id: str
+    author_id: str
+    author_name: str
+    content: str
+    featured_strain: Optional[str] = None
+    vibes: List[str] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    media_url: Optional[str] = None
+    engagement: dict = Field(default_factory=lambda: {"likes": 0, "comments": 0})
+
+
+class SocialFeedResponse(BaseModel):
+    posts: List[SocialPost]
+    next_refresh: datetime
+
+
+class CreatePostRequest(BaseModel):
+    author_id: str
+    content: str
+    featured_strain: Optional[str] = None
+    vibes: List[str] = Field(default_factory=list)
+    media_url: Optional[str] = None
+
+
+class BuddyMatchRequest(BaseModel):
+    profile_id: str
+    desired_vibes: List[str] = Field(default_factory=list)
+    preferred_strains: List[str] = Field(default_factory=list)
+
+
+class BuddyMatchResponse(BaseModel):
+    profile_id: str
+    matches: List[SocialProfile]
+    lounge_suggestions: List[str]
+
+
+class SocialDailyRefreshRequest(BaseModel):
+    highlight_strains: List[str] = Field(default_factory=list)
+
+
+class SocialDailyRefreshResponse(BaseModel):
+    refreshed_at: datetime
+    new_posts: List[SocialPost]
+    trending_tags: List[str]
+
+
+MOCK_STRAINS: List[Strain] = [
+    Strain(
+        name="Gelato 41",
+        genetics="Sunset Sherbet x Thin Mint GSC",
+        dominant_terpenes=["limonene", "caryophyllene", "linalool"],
+        effects=["creative", "uplifted", "relaxed"],
+        thc_percent=27.8,
+        cbd_percent=0.1,
+        aroma=["sweet", "dessert", "berry"],
+        clean_badge=True,
+        last_verified=datetime(2024, 1, 11, 12, 0, 0),
+        lab_report_url="https://labs.example.com/gelato41.pdf",
+        notes="Fresh drop — zero residual solvents detected.",
+    ),
+    Strain(
+        name="Zkittlez",
+        genetics="Grape Ape x Grapefruit",
+        dominant_terpenes=["humulene", "limonene", "myrcene"],
+        effects=["happy", "euphoric", "focused"],
+        thc_percent=24.2,
+        cbd_percent=0.2,
+        aroma=["candy", "tropical", "citrus"],
+        clean_badge=True,
+        last_verified=datetime(2024, 1, 5, 9, 30, 0),
+        lab_report_url="https://labs.example.com/zkittlez.pdf",
+        notes="Drop alert! Reserve before the lounge sells out.",
+    ),
+    Strain(
+        name="Blue Dream",
+        genetics="Blueberry x Haze",
+        dominant_terpenes=["myrcene", "pinene", "caryophyllene"],
+        effects=["relaxed", "uplifted", "creative"],
+        thc_percent=21.5,
+        cbd_percent=0.3,
+        aroma=["sweet", "berry", "earthy"],
+        clean_badge=False,
+        last_verified=datetime(2023, 12, 28, 16, 45, 0),
+        lab_report_url="https://labs.example.com/bluedream.pdf",
+        notes="COA under review for trace pesticides — standby for update.",
+    ),
+]
+
+
+MOCK_MENU_DATA: List[dict] = [
+    {
+        "dispensary_id": "oakland-botanica",
+        "dispensary_name": "Oakland Botanica",
+        "distance_miles": 12.4,
+        "last_synced": datetime(2024, 1, 14, 9, 30, 0),
+        "lounge_ready": True,
+        "loyalty_deals": [
+            "Wake-n-Bake BOGO before 11am",
+            "Terp Titans members save 15% on solventless",
+        ],
+        "items": [
+            {
+                "sku": "OB-GEL41-35",
+                "name": "Gelato 41 Eighth",
+                "category": "Flower",
+                "thc_percent": 32.4,
+                "cbd_percent": 0.1,
+                "price": 54.0,
+                "unit": "eighth",
+                "deal": None,
+                "tags": ["dessert", "creative", "clean-cert"],
+            },
+            {
+                "sku": "OB-PAPAYA-1G",
+                "name": "Papaya Live Rosin",
+                "category": "Concentrate",
+                "thc_percent": 78.2,
+                "cbd_percent": 0.2,
+                "price": 65.0,
+                "unit": "gram",
+                "deal": "Pair with Guava Kush pre-rolls for $20 off",
+                "tags": ["solventless", "lounge-ready"],
+            },
+        ],
+    },
+    {
+        "dispensary_id": "mission-haze",
+        "dispensary_name": "Mission Haze Club",
+        "distance_miles": 4.3,
+        "last_synced": datetime(2024, 1, 14, 10, 15, 0),
+        "lounge_ready": True,
+        "loyalty_deals": [
+            "Happy Hour 4:20pm - 6pm 20% off carts",
+            "Lounge buddies get free mocktails on Thursdays",
+        ],
+        "items": [
+            {
+                "sku": "MH-ZKIT-7G",
+                "name": "Zkittlez Small Batch",
+                "category": "Flower",
+                "thc_percent": 28.7,
+                "cbd_percent": 0.3,
+                "price": 120.0,
+                "unit": "quarter",
+                "deal": "Reserve with a lounge table and get infused gummies", 
+                "tags": ["party", "fruit", "lounge"],
+            },
+            {
+                "sku": "MH-LIMON-10PK",
+                "name": "Limonene Lift Gummies",
+                "category": "Edible",
+                "thc_percent": 5.0,
+                "cbd_percent": 2.0,
+                "price": 28.0,
+                "unit": "pack",
+                "deal": None,
+                "tags": ["microdose", "daytime"],
+            },
+        ],
+    },
+    {
+        "dispensary_id": "berkeley-bloom",
+        "dispensary_name": "Berkeley Bloom Lounge",
+        "distance_miles": 18.9,
+        "last_synced": datetime(2024, 1, 13, 21, 0, 0),
+        "lounge_ready": False,
+        "loyalty_deals": [
+            "Students save 10% with ID",
+            "Bring-a-buddy: both get terp flights",
+        ],
+        "items": [
+            {
+                "sku": "BB-BLUE-35",
+                "name": "Blue Dream Sun Grown",
+                "category": "Flower",
+                "thc_percent": 22.1,
+                "cbd_percent": 0.4,
+                "price": 42.0,
+                "unit": "eighth",
+                "deal": "Bundle with Dreamy cart for $10 off",
+                "tags": ["classic", "creative"],
+            },
+            {
+                "sku": "BB-ICE-500",
+                "name": "Ice Cream Cake Vape",
+                "category": "Cartridge",
+                "thc_percent": 85.0,
+                "cbd_percent": 0.0,
+                "price": 48.0,
+                "unit": "half-gram",
+                "deal": None,
+                "tags": ["dessert", "evening"],
+            },
+        ],
+    },
+]
+
+
+SOCIAL_PROFILES: List[SocialProfile] = [
+    SocialProfile(
+        profile_id="ashley-terp-queen",
+        display_name="Ashley Terp Queen",
+        favorite_strains=["Gelato 41", "Papaya", "RS11"],
+        current_smoke="Gelato 41",
+        lounge_homebase="Mission Haze Club",
+        vibes=["creative", "gallery-hop", "dessert terp"],
+        bio="Designing by day, curating the loudest terp flights by night.",
+    ),
+    SocialProfile(
+        profile_id="lofi-lounger",
+        display_name="LoFi Lounger",
+        favorite_strains=["Blue Dream", "Super Lemon Haze"],
+        current_smoke="Blue Dream",
+        lounge_homebase="Berkeley Bloom Lounge",
+        vibes=["chill", "vinyl", "sunset-sesh"],
+        bio="Host of Sunday mellow sessions — bring your best playlist.",
+    ),
+    SocialProfile(
+        profile_id="caryophyllene-king",
+        display_name="Caryophyllene King",
+        favorite_strains=["Zkittlez", "Gary Payton"],
+        current_smoke="Zkittlez",
+        lounge_homebase="Oakland Botanica",
+        vibes=["party", "game-night", "neo-soul"],
+        bio="Always scouting funky terps + hoops highlights.",
+    ),
+]
+
+
+SOCIAL_POSTS: List[SocialPost] = [
+    SocialPost(
+        post_id="post-001",
+        author_id="ashley-terp-queen",
+        author_name="Ashley Terp Queen",
+        content="Tapped into a new batch of Gelato 41 — zero residuals, terps hitting like candy clouds.",
+        featured_strain="Gelato 41",
+        vibes=["creative", "dessert"],
+        media_url="https://images.example.com/gelato41-drop.jpg",
+        engagement={"likes": 128, "comments": 12},
+    ),
+    SocialPost(
+        post_id="post-002",
+        author_id="lofi-lounger",
+        author_name="LoFi Lounger",
+        content="Hosting a vinyl + vapor session this Friday. Bring your fave sativa and good vibes.",
+        featured_strain="Blue Dream",
+        vibes=["chill", "community"],
+        media_url="https://images.example.com/lofi-lounge.jpg",
+        engagement={"likes": 86, "comments": 9},
+    ),
+    SocialPost(
+        post_id="post-003",
+        author_id="caryophyllene-king",
+        author_name="Caryophyllene King",
+        content="Mission Haze just loaded a Zkittlez cart deal — meeting up for a lounge run tonight.",
+        featured_strain="Zkittlez",
+        vibes=["party", "night-out"],
+        engagement={"likes": 64, "comments": 6},
+    ),
+]
+
+
+def _menus_within_radius(radius_miles: float) -> List[DispensaryMenu]:
+    now = datetime.utcnow()
+    refreshed: List[DispensaryMenu] = []
+    for record in MOCK_MENU_DATA:
+        if record["distance_miles"] <= radius_miles:
+            record["last_synced"] = now
+            refreshed.append(DispensaryMenu(**record))
+    return refreshed
+
+
+def _apply_deals_to_menu(menu: DispensaryMenu, request: DealApplicationRequest) -> List[MenuItem]:
+    applied: List[MenuItem] = []
+    for item in menu.items:
+        deal_text = item.deal
+        tags_text = " ".join(item.tags).lower()
+        if request.prefer_clean and "clean" in tags_text:
+            deal_text = deal_text or "Clean badge verified — add to lounge flight"
+        if request.favorite_terpenes:
+            terp_hits = [
+                terp for terp in request.favorite_terpenes if terp.lower() in tags_text
+            ]
+            if terp_hits:
+                deal_text = deal_text or f"Stacks with terp crush: {', '.join(terp_hits)}"
+        if request.vibe and request.vibe.lower() in tags_text:
+            deal_text = deal_text or f"Dialed for {request.vibe} nights"
+        data = item.dict()
+        data["deal"] = deal_text
+        applied.append(MenuItem(**data))
+    return applied
+
+
+def _get_menu_by_id(dispensary_id: str) -> Optional[DispensaryMenu]:
+    for record in MOCK_MENU_DATA:
+        if record["dispensary_id"] == dispensary_id:
+            return DispensaryMenu(**record)
+    return None
+
+
+@app.get("/strains/search", response_model=StrainSearchResponse)
+def search_strains(q: str = Query("", description="Search terms for strain name or effects")) -> StrainSearchResponse:
+    """Return a filtered list of mock strains.
+
+    In a production build this would call into Watson Discovery + MongoDB Atlas
+    for hybrid retrieval.
+    """
+    normalized_query = q.strip().lower()
+    if not normalized_query:
+        results = MOCK_STRAINS
+    else:
+        results = [
+            strain
+            for strain in MOCK_STRAINS
+            if normalized_query in strain.name.lower()
+            or any(normalized_query in terp.lower() for terp in strain.dominant_terpenes)
+            or any(normalized_query in effect.lower() for effect in strain.effects)
+        ]
+    return StrainSearchResponse(query=q, results=results)
+
+
+@app.post("/menus/sync", response_model=MenuSyncResponse)
+def sync_menus(payload: MenuSyncRequest) -> MenuSyncResponse:
+    menus = _menus_within_radius(payload.radius_miles)
+    if payload.categories:
+        categories = {category.lower() for category in payload.categories}
+        filtered: List[DispensaryMenu] = []
+        for menu in menus:
+            items = [
+                item for item in menu.items if item.category.lower() in categories
+            ]
+            if items:
+                filtered.append(menu.copy(update={"items": items}))
+        menus = filtered
+    return MenuSyncResponse(
+        synced_at=datetime.utcnow(),
+        radius_miles=payload.radius_miles,
+        menus=menus,
+    )
+
+
+@app.get("/menus/nearby", response_model=MenuSyncResponse)
+def list_nearby_menus(
+    lat: float = Query(..., description="Latitude for the search origin"),
+    lon: float = Query(..., description="Longitude for the search origin"),
+    radius_miles: float = Query(60, gt=0, le=120, description="Radius in miles"),
+    categories: Optional[str] = Query(
+        None, description="Comma separated categories to filter (e.g. Flower,Edible)"
+    ),
+) -> MenuSyncResponse:
+    del lat, lon  # Placeholder until hooked to a geo lookup or mapping service.
+    menus = _menus_within_radius(radius_miles)
+    if categories:
+        requested = {
+            category.strip().lower()
+            for category in categories.split(",")
+            if category.strip()
+        }
+        if requested:
+            filtered: List[DispensaryMenu] = []
+            for menu in menus:
+                items = [
+                    item for item in menu.items if item.category.lower() in requested
+                ]
+                if items:
+                    filtered.append(menu.copy(update={"items": items}))
+            menus = filtered
+    return MenuSyncResponse(
+        synced_at=datetime.utcnow(),
+        radius_miles=radius_miles,
+        menus=menus,
+    )
+
+
+@app.post("/lounge/deals/apply", response_model=DealApplicationResponse)
+def apply_lounge_deals(payload: DealApplicationRequest) -> DealApplicationResponse:
+    menu = _get_menu_by_id(payload.dispensary_id)
+    if not menu:
+        raise HTTPException(status_code=404, detail="Dispensary menu not found")
+
+    applied_items = _apply_deals_to_menu(menu, payload)
+
+    connection_notes: List[str] = []
+    for profile in SOCIAL_PROFILES:
+        vibe_overlap = False
+        if payload.vibe:
+            vibe_overlap = any(
+                payload.vibe.lower() in vibe.lower() for vibe in profile.vibes
+            )
+        terp_overlap = False
+        if payload.favorite_terpenes:
+            terp_overlap = any(
+                terp.lower() in (profile.current_smoke or "").lower()
+                for terp in payload.favorite_terpenes
+            )
+        if vibe_overlap or terp_overlap:
+            connection_notes.append(
+                f"{profile.display_name} is seshing on {profile.current_smoke} at {profile.lounge_homebase}."
+            )
+        if len(connection_notes) >= 3:
+            break
+
+    lounge_recommendations = [
+        f"{menu.dispensary_name} perks: {', '.join(menu.loyalty_deals[:2])}"
+        if menu.loyalty_deals
+        else f"{menu.dispensary_name} — ask staff for nightly specials"
+    ]
+    if menu.lounge_ready:
+        lounge_recommendations.append("Lounge ready: reserve a table straight from chat.")
+
+    return DealApplicationResponse(
+        dispensary_id=payload.dispensary_id,
+        applied_items=applied_items,
+        connection_notes=connection_notes,
+        lounge_recommendations=lounge_recommendations,
+    )
+
+
+@app.get("/social/profiles", response_model=List[SocialProfile])
+def list_social_profiles() -> List[SocialProfile]:
+    return SOCIAL_PROFILES
+
+
+@app.get("/social/feed", response_model=SocialFeedResponse)
+def get_social_feed() -> SocialFeedResponse:
+    posts = sorted(SOCIAL_POSTS, key=lambda post: post.created_at, reverse=True)
+    next_refresh = datetime.utcnow().replace(hour=23, minute=59, second=0, microsecond=0)
+    return SocialFeedResponse(posts=posts, next_refresh=next_refresh)
+
+
+@app.post("/social/posts", response_model=SocialPost)
+def create_social_post(payload: CreatePostRequest) -> SocialPost:
+    author = next(
+        (profile for profile in SOCIAL_PROFILES if profile.profile_id == payload.author_id),
+        None,
+    )
+    if not author:
+        raise HTTPException(status_code=404, detail="Author profile not found")
+
+    post = SocialPost(
+        post_id=f"post-{len(SOCIAL_POSTS) + 1:03d}-{int(datetime.utcnow().timestamp())}",
+        author_id=author.profile_id,
+        author_name=author.display_name,
+        content=payload.content,
+        featured_strain=payload.featured_strain,
+        vibes=payload.vibes or author.vibes,
+        media_url=payload.media_url,
+        engagement={"likes": 0, "comments": 0},
+    )
+    SOCIAL_POSTS.append(post)
+    author.current_smoke = payload.featured_strain or author.current_smoke
+    return post
+
+
+@app.post("/social/buddies/match", response_model=BuddyMatchResponse)
+def match_lounge_buddies(payload: BuddyMatchRequest) -> BuddyMatchResponse:
+    profile = next(
+        (candidate for candidate in SOCIAL_PROFILES if candidate.profile_id == payload.profile_id),
+        None,
+    )
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+
+    matches: List[SocialProfile] = []
+    for candidate in SOCIAL_PROFILES:
+        if candidate.profile_id == profile.profile_id:
+            continue
+        vibe_overlap = any(
+            vibe.lower() in {v.lower() for v in candidate.vibes}
+            for vibe in (payload.desired_vibes or profile.vibes)
+        )
+        strain_overlap = any(
+            strain.lower() in {s.lower() for s in candidate.favorite_strains}
+            for strain in (payload.preferred_strains or profile.favorite_strains)
+        )
+        if vibe_overlap or strain_overlap:
+            matches.append(candidate)
+        if len(matches) >= 3:
+            break
+
+    lounge_suggestions = list(
+        {
+            candidate.lounge_homebase
+            for candidate in matches
+            if candidate.lounge_homebase
+        }
+    )
+
+    return BuddyMatchResponse(
+        profile_id=payload.profile_id,
+        matches=matches,
+        lounge_suggestions=lounge_suggestions,
+    )
+
+
+@app.post("/social/daily-refresh", response_model=SocialDailyRefreshResponse)
+def social_daily_refresh(payload: SocialDailyRefreshRequest) -> SocialDailyRefreshResponse:
+    highlight = payload.highlight_strains or [strain.name for strain in MOCK_STRAINS[:2]]
+    new_posts: List[SocialPost] = []
+    for strain_name in highlight:
+        matched_profile = SOCIAL_PROFILES[0]
+        if highlight.index(strain_name) < len(SOCIAL_PROFILES):
+            matched_profile = SOCIAL_PROFILES[highlight.index(strain_name)]
+        post = SocialPost(
+            post_id=f"post-{len(SOCIAL_POSTS) + 1:03d}-{int(datetime.utcnow().timestamp())}",
+            author_id=matched_profile.profile_id,
+            author_name=matched_profile.display_name,
+            content=f"Daily drop: {strain_name} is live with fresh COAs. Who's rolling through tonight?",
+            featured_strain=strain_name,
+            vibes=list({*matched_profile.vibes, "daily-drop"}),
+            engagement={"likes": 0, "comments": 0},
+        )
+        SOCIAL_POSTS.append(post)
+        matched_profile.current_smoke = strain_name
+        new_posts.append(post)
+
+    vibe_counts = {}
+    for post in SOCIAL_POSTS:
+        for vibe in post.vibes:
+            vibe_counts[vibe] = vibe_counts.get(vibe, 0) + 1
+    trending_tags = [tag for tag, _ in sorted(vibe_counts.items(), key=lambda item: item[1], reverse=True)[:5]]
+
+    return SocialDailyRefreshResponse(
+        refreshed_at=datetime.utcnow(),
+        new_posts=new_posts,
+        trending_tags=trending_tags,
+    )
+
+
+@app.post("/ingest_coa", response_model=COAIngestResponse)
+def ingest_coa(payload: COAIngestRequest) -> COAIngestResponse:
+    """Mock COA ingestion that flags analytes above threshold."""
+    flagged = [
+        analyte.name
+        for analyte in payload.analytes
+        if analyte.value_ppm > analyte.limit_ppm
+    ]
+    return COAIngestResponse(
+        strain_name=payload.strain_name,
+        lab_name=payload.lab_name,
+        source_url=payload.source_url,
+        flagged_analytes=flagged,
+        clean=len(flagged) == 0,
+        ingested_at=datetime.utcnow(),
+    )
+
+
+@app.post("/orders/reserve", response_model=ReserveResponse)
+def reserve_order(payload: ReserveRequest) -> ReserveResponse:
+    if not payload.items:
+        raise HTTPException(status_code=400, detail="Reservation requires at least one item")
+
+    reservation_id = f"RSV-{datetime.utcnow():%Y%m%d%H%M%S}"
+    message = (
+        "Reservation locked and loaded. Expect a ping once the staff confirms pickup."
+    )
+    return ReserveResponse(reservation_id=reservation_id, status="pending", message=message)
+
+
+@app.post("/notify", response_model=NotificationResponse)
+def send_notification(payload: NotificationRequest) -> NotificationResponse:
+    """Mock notification sender.
+
+    In production this would fan out to Twilio, SendGrid, Meta, etc.
+    """
+    supported_channels = {"sms", "email", "push", "voice"}
+    if payload.channel not in supported_channels:
+        raise HTTPException(status_code=422, detail="Unsupported channel")
+
+    detail = (
+        f"Queued {payload.channel} notification for {payload.recipient}."
+    )
+    return NotificationResponse(status="queued", detail=detail)
+
+
+@app.get("/health")
+def health_check() -> dict[str, str]:
+    return {"status": "ok", "timestamp": datetime.utcnow().isoformat()}
+
+
+__all__ = [
+    "app",
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.109.2
+uvicorn[standard]==0.27.1
+pydantic==1.10.14
+python-dotenv==1.0.1

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,1297 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BudSense.AI Prototype</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" integrity="sha512-PN/G1RyhokW2N7DbStO2Qe6hw2yffA9H9n1tFoZT3zh0+BTtPlqvGjufH6G+j6lJzi10BGSAdoo6+nWQBaIj2Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/@headlessui/react@1.7.17/dist/headlessui.umd.production.min.js"></script>
+    <script>
+      window.tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              budgreen: "#044c29",
+              haze: "#6b21a8",
+              neon: "#ff6f00",
+              midnight: "#0f172a",
+            },
+            fontFamily: {
+              groove: ['"Space Grotesk"', "sans-serif"],
+            },
+          },
+        },
+      };
+      window.BUDSENSE_API_BASE = window.BUDSENSE_API_BASE || "http://localhost:8000";
+    </script>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap"
+    />
+    <style>
+      body {
+        background: radial-gradient(circle at 20% 20%, rgba(107, 33, 168, 0.4), transparent 60%),
+          radial-gradient(circle at 80% 0%, rgba(255, 111, 0, 0.4), transparent 55%),
+          #020617;
+        min-height: 100vh;
+        font-family: "Space Grotesk", sans-serif;
+      }
+      .scrollbar::-webkit-scrollbar {
+        width: 6px;
+      }
+      .scrollbar::-webkit-scrollbar-thumb {
+        background-color: rgba(255, 255, 255, 0.25);
+        border-radius: 999px;
+      }
+    </style>
+  </head>
+  <body class="text-slate-100">
+    <div id="root"></div>
+    <script type="text/javascript">
+      const { useState, useEffect, useMemo } = React;
+
+      const funkyIntros = [
+        "Yo! Fresh drops landing — what vibe are you hunting tonight?",
+        "Welcome back! Ready for a terp adventure?",
+        "Hey legend! Let me dial in a clean, certified strain for you.",
+      ];
+
+      const useChatbot = () => {
+        const [messages, setMessages] = useState(() => [
+          {
+            id: crypto.randomUUID(),
+            role: "budtender",
+            text: funkyIntros[Math.floor(Math.random() * funkyIntros.length)],
+            timestamp: new Date(),
+          },
+        ]);
+        const [loading, setLoading] = useState(false);
+        const [searchResults, setSearchResults] = useState([]);
+
+        const addMessage = (message) => {
+          setMessages((prev) => [...prev, { ...message, id: crypto.randomUUID(), timestamp: new Date() }]);
+        };
+
+        const fetchStrains = async (query) => {
+          setLoading(true);
+          try {
+            const response = await fetch(
+              `${window.BUDSENSE_API_BASE}/strains/search?q=${encodeURIComponent(query)}`
+            );
+            const payload = await response.json();
+            setSearchResults(payload.results || []);
+            return payload.results || [];
+          } catch (error) {
+            console.error(error);
+            addMessage({
+              role: "budtender",
+              text: "Hmm, Watson's antennas are fuzzy. Try again in a sec?",
+            });
+          } finally {
+            setLoading(false);
+          }
+          return [];
+        };
+
+        const sendUserMessage = async (text) => {
+          if (!text?.trim()) return;
+          const trimmed = text.trim();
+          addMessage({ role: "user", text: trimmed });
+          setLoading(true);
+          const results = await fetchStrains(trimmed);
+          if (results.length) {
+            const top = results[0];
+            addMessage({
+              role: "budtender",
+              text: `Got you! ${top.name} clocks in at ${top.thc_percent}% THC with ${top.dominant_terpenes.join(", ")} terps. Want me to stash a ${top.clean_badge ? "certified clean" : "review pending"} eighth?`,
+              strain: top,
+            });
+          } else {
+            addMessage({
+              role: "budtender",
+              text: "Couldn't find that one in the verified vault. Want me to keep scouting?",
+            });
+          }
+          setLoading(false);
+        };
+
+        return {
+          messages,
+          loading,
+          searchResults,
+          sendUserMessage,
+          addMessage,
+        };
+      };
+
+      const useMenuSync = () => {
+        const [menus, setMenus] = useState([]);
+        const [lastSynced, setLastSynced] = useState(null);
+        const [loading, setLoading] = useState(false);
+
+        const syncMenus = async (radiusMiles = 60) => {
+          setLoading(true);
+          try {
+            const params = new URLSearchParams({
+              lat: "37.7749",
+              lon: "-122.4194",
+              radius_miles: String(radiusMiles),
+            });
+            const response = await fetch(
+              `${window.BUDSENSE_API_BASE}/menus/nearby?${params.toString()}`
+            );
+            const payload = await response.json();
+            setMenus(payload.menus || []);
+            setLastSynced(payload.synced_at || null);
+          } catch (error) {
+            console.error(error);
+          } finally {
+            setLoading(false);
+          }
+        };
+
+        const applyDeals = async (dispensaryId, options = {}) => {
+          try {
+            const response = await fetch(`${window.BUDSENSE_API_BASE}/lounge/deals/apply`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ dispensary_id: dispensaryId, ...options }),
+            });
+            const payload = await response.json();
+            setMenus((prev) =>
+              prev.map((menu) =>
+                menu.dispensary_id === dispensaryId
+                  ? {
+                      ...menu,
+                      items: payload.applied_items || menu.items,
+                      connection_notes: payload.connection_notes || [],
+                      lounge_recommendations: payload.lounge_recommendations || [],
+                    }
+                  : menu
+              )
+            );
+            return payload;
+          } catch (error) {
+            console.error(error);
+            throw error;
+          }
+        };
+
+        useEffect(() => {
+          syncMenus();
+        }, []);
+
+        return {
+          menus,
+          lastSynced,
+          loading,
+          syncMenus,
+          applyDeals,
+        };
+      };
+
+      const useSocialNetwork = () => {
+        const [profiles, setProfiles] = useState([]);
+        const [feed, setFeed] = useState([]);
+        const [nextRefresh, setNextRefresh] = useState(null);
+        const [trending, setTrending] = useState([]);
+        const [matches, setMatches] = useState([]);
+        const [matchSummary, setMatchSummary] = useState({ loungeSuggestions: [] });
+
+        const extractTrending = (posts) => {
+          const tally = {};
+          posts.forEach((post) => {
+            (post.vibes || []).forEach((vibe) => {
+              tally[vibe] = (tally[vibe] || 0) + 1;
+            });
+          });
+          return Object.entries(tally)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 5)
+            .map(([vibe]) => vibe);
+        };
+
+        const loadProfiles = async () => {
+          try {
+            const response = await fetch(`${window.BUDSENSE_API_BASE}/social/profiles`);
+            const payload = await response.json();
+            setProfiles(payload || []);
+          } catch (error) {
+            console.error(error);
+          }
+        };
+
+        const loadFeed = async () => {
+          try {
+            const response = await fetch(`${window.BUDSENSE_API_BASE}/social/feed`);
+            const payload = await response.json();
+            setFeed(payload.posts || []);
+            setNextRefresh(payload.next_refresh || null);
+            setTrending(extractTrending(payload.posts || []));
+          } catch (error) {
+            console.error(error);
+          }
+        };
+
+        const dailyRefresh = async () => {
+          try {
+            const highlight = profiles
+              .slice(0, 3)
+              .map((profile) => profile.current_smoke || profile.favorite_strains?.[0])
+              .filter(Boolean);
+            const response = await fetch(`${window.BUDSENSE_API_BASE}/social/daily-refresh`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ highlight_strains: highlight }),
+            });
+            const payload = await response.json();
+            setFeed((prev) => [...(payload.new_posts || []), ...prev]);
+            setTrending(payload.trending_tags || []);
+            setNextRefresh(payload.refreshed_at || nextRefresh);
+            return payload;
+          } catch (error) {
+            console.error(error);
+          }
+        };
+
+        const matchBuddies = async (profileId, desiredVibes = []) => {
+          try {
+            const profile = profiles.find((candidate) => candidate.profile_id === profileId);
+            const response = await fetch(`${window.BUDSENSE_API_BASE}/social/buddies/match`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                profile_id: profileId,
+                desired_vibes: desiredVibes,
+                preferred_strains: profile?.favorite_strains?.slice(0, 3) || [],
+              }),
+            });
+            const payload = await response.json();
+            setMatches(payload.matches || []);
+            setMatchSummary({ loungeSuggestions: payload.lounge_suggestions || [] });
+            return payload;
+          } catch (error) {
+            console.error(error);
+          }
+        };
+
+        useEffect(() => {
+          loadProfiles();
+          loadFeed();
+        }, []);
+
+        return {
+          profiles,
+          feed,
+          nextRefresh,
+          trending,
+          matches,
+          matchSummary,
+          loadProfiles,
+          loadFeed,
+          dailyRefresh,
+          matchBuddies,
+        };
+      };
+
+      const MessageBubble = ({ message }) => {
+        const isUser = message.role === "user";
+        return (
+          React.createElement(
+            "div",
+            {
+              className: `flex ${isUser ? "justify-end" : "justify-start"}`,
+            },
+            React.createElement(
+              "div",
+              {
+                className: `max-w-lg rounded-3xl px-5 py-4 mb-4 text-sm md:text-base shadow-xl backdrop-blur-md border border-white/10 ${
+                  isUser
+                    ? "bg-neon/80 text-slate-900"
+                    : "bg-white/10 text-slate-100"
+                }`,
+              },
+              React.createElement(
+                "div",
+                { className: "font-semibold uppercase text-xs tracking-wide mb-1" },
+                isUser ? "You" : "BudSense Bot"
+              ),
+              React.createElement("p", { className: "leading-relaxed" }, message.text),
+              message.strain &&
+                React.createElement(
+                  "div",
+                  { className: "mt-4 grid grid-cols-2 gap-2 text-xs" },
+                  [
+                    React.createElement(
+                      "div",
+                      { key: "thc", className: "bg-midnight/50 rounded-xl p-3 border border-white/10" },
+                      React.createElement("div", { className: "text-xs uppercase tracking-wide text-white/60" }, "THC"),
+                      React.createElement("div", { className: "text-lg font-bold" }, `${message.strain.thc_percent}%`)
+                    ),
+                    React.createElement(
+                      "div",
+                      { key: "terps", className: "bg-midnight/50 rounded-xl p-3 border border-white/10" },
+                      React.createElement(
+                        "div",
+                        { className: "text-xs uppercase tracking-wide text-white/60" },
+                        "Terpenes"
+                      ),
+                      React.createElement(
+                        "div",
+                        { className: "text-lg font-bold" },
+                        message.strain.dominant_terpenes.join(", ")
+                      )
+                    ),
+                  ]
+                )
+            )
+          )
+        );
+      };
+
+      const SearchCard = ({ strain, onReserve }) => {
+        const badgeClasses = strain.clean_badge
+          ? "bg-emerald-500/20 text-emerald-200 border-emerald-400/40"
+          : "bg-amber-500/20 text-amber-200 border-amber-400/40";
+
+        return (
+          React.createElement(
+            "div",
+            {
+              className:
+                "bg-white/10 rounded-3xl p-6 border border-white/10 backdrop-blur-xl shadow-2xl flex flex-col gap-3",
+            },
+            React.createElement(
+              "div",
+              { className: "flex items-center justify-between" },
+              React.createElement(
+                "h3",
+                { className: "text-xl font-bold text-white" },
+                strain.name
+              ),
+              React.createElement(
+                "span",
+                { className: `px-3 py-1 rounded-full text-xs font-semibold border ${badgeClasses}` },
+                strain.clean_badge ? "Clean Certified" : "Review Pending"
+              )
+            ),
+            React.createElement(
+              "p",
+              { className: "text-sm text-white/70" },
+              strain.genetics
+            ),
+            React.createElement(
+              "div",
+              { className: "grid grid-cols-2 gap-2 text-xs text-white/80" },
+              [
+                React.createElement(
+                  "div",
+                  { key: "effects" },
+                  React.createElement("p", { className: "uppercase text-white/40" }, "Effects"),
+                  React.createElement("p", { className: "font-semibold" }, strain.effects.join(", "))
+                ),
+                React.createElement(
+                  "div",
+                  { key: "terpenes" },
+                  React.createElement("p", { className: "uppercase text-white/40" }, "Terpenes"),
+                  React.createElement("p", { className: "font-semibold" }, strain.dominant_terpenes.join(", "))
+                ),
+              ]
+            ),
+            React.createElement(
+              "button",
+              {
+                className:
+                  "mt-4 inline-flex items-center justify-center gap-2 px-4 py-3 rounded-full bg-neon text-slate-900 font-semibold shadow-lg hover:bg-orange-400 transition",
+                onClick: () => onReserve(strain),
+              },
+              "Reserve ", strain.name
+            )
+          )
+        );
+      };
+
+      const MenuCard = ({ menu, onApplyDeals }) => {
+        const [applying, setApplying] = useState(false);
+        const [applied, setApplied] = useState(false);
+        const [error, setError] = useState(false);
+
+        const defaultTerps = useMemo(() => {
+          const terps = new Set();
+          (menu.items || []).forEach((item) => {
+            (item.tags || []).forEach((tag) => terps.add(tag));
+          });
+          return Array.from(terps).slice(0, 3);
+        }, [menu]);
+
+        useEffect(() => {
+          const hasConnections = (menu.connection_notes || []).length > 0;
+          setApplied(hasConnections);
+        }, [menu.connection_notes]);
+
+        const lastSynced = menu.last_synced
+          ? new Date(menu.last_synced).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+          : "—";
+
+        const handleApply = async () => {
+          setApplying(true);
+          setError(false);
+          try {
+            await onApplyDeals(menu.dispensary_id, {
+              vibe: menu.lounge_ready ? "lounge" : "chill",
+              prefer_clean: true,
+              favorite_terpenes: defaultTerps,
+            });
+            setApplied(true);
+          } catch (applyError) {
+            console.error(applyError);
+            setError(true);
+          } finally {
+            setApplying(false);
+          }
+        };
+
+        return React.createElement(
+          "div",
+          {
+            className:
+              "bg-white/10 border border-white/10 rounded-3xl p-6 space-y-4 backdrop-blur-xl shadow-xl",
+          },
+          React.createElement(
+            "div",
+            { className: "flex items-start justify-between gap-4" },
+            React.createElement(
+              "div",
+              null,
+              React.createElement(
+                "h3",
+                { className: "text-xl font-semibold text-white" },
+                menu.dispensary_name
+              ),
+              React.createElement(
+                "p",
+                { className: "text-sm text-white/60" },
+                `${menu.distance_miles?.toFixed?.(1) || menu.distance_miles} miles · Last synced ${lastSynced}`
+              )
+            ),
+            menu.lounge_ready &&
+              React.createElement(
+                "span",
+                {
+                  className:
+                    "inline-flex px-3 py-1 rounded-full text-xs font-semibold bg-emerald-500/20 text-emerald-200 border border-emerald-400/30",
+                },
+                "Lounge Ready"
+              )
+          ),
+          React.createElement(
+            "div",
+            { className: "grid gap-3" },
+            (menu.items || []).map((item) =>
+              React.createElement(
+                "div",
+                {
+                  key: item.sku,
+                  className:
+                    "bg-midnight/50 border border-white/10 rounded-2xl p-4 flex flex-col gap-2",
+                },
+                React.createElement(
+                  "div",
+                  { className: "flex items-start justify-between gap-3" },
+                  React.createElement(
+                    "div",
+                    null,
+                    React.createElement(
+                      "p",
+                      { className: "text-sm uppercase tracking-wide text-white/50" },
+                      item.category
+                    ),
+                    React.createElement(
+                      "h4",
+                      { className: "text-lg font-semibold text-white" },
+                      item.name
+                    )
+                  ),
+                  React.createElement(
+                    "div",
+                    { className: "text-right" },
+                    React.createElement(
+                      "p",
+                      { className: "text-sm text-white/60" },
+                      `${item.thc_percent}% THC`
+                    ),
+                    React.createElement(
+                      "p",
+                      { className: "text-base font-semibold text-white" },
+                      `$${item.price}`
+                    )
+                  )
+                ),
+                item.deal &&
+                  React.createElement(
+                    "p",
+                    { className: "text-xs text-neon" },
+                    item.deal
+                  ),
+                item.tags?.length > 0 &&
+                  React.createElement(
+                    "div",
+                    { className: "flex flex-wrap gap-2 text-[10px] uppercase text-white/50" },
+                    item.tags.map((tag) =>
+                      React.createElement(
+                        "span",
+                        {
+                          key: `${item.sku}-${tag}`,
+                          className:
+                            "px-2 py-1 rounded-full border border-white/10 bg-white/5",
+                        },
+                        tag
+                      )
+                    )
+                  )
+              )
+            )
+          ),
+          React.createElement(
+            "div",
+            { className: "flex flex-wrap items-center gap-3" },
+            React.createElement(
+              "button",
+              {
+                className:
+                  "inline-flex items-center gap-2 px-4 py-2 rounded-full bg-neon text-slate-900 font-semibold hover:bg-orange-400 transition disabled:opacity-60",
+                onClick: handleApply,
+                disabled: applying,
+              },
+              applying ? "Applying deals..." : applied ? "Deals synced" : "Apply lounge deals"
+            ),
+            React.createElement(
+              "span",
+              { className: "text-xs text-white/60" },
+              `Auto terps: ${defaultTerps.join(", ") || "classic"}`
+            )
+          ),
+          error &&
+            React.createElement(
+              "p",
+              { className: "text-xs text-rose-300" },
+              "Could not reach the deal engine. Try again."
+            ),
+          (menu.connection_notes || []).length > 0 &&
+            React.createElement(
+              "div",
+              { className: "bg-emerald-500/10 border border-emerald-400/30 rounded-2xl p-4 space-y-2" },
+              React.createElement(
+                "p",
+                { className: "text-sm font-semibold text-emerald-200" },
+                "Connections Found"
+              ),
+              React.createElement(
+                "ul",
+                { className: "list-disc list-inside text-xs text-emerald-100/80 space-y-1" },
+                menu.connection_notes.map((note, index) =>
+                  React.createElement("li", { key: `${menu.dispensary_id}-note-${index}` }, note)
+                )
+              )
+            ),
+          (menu.lounge_recommendations || []).length > 0 &&
+            React.createElement(
+              "div",
+              { className: "bg-white/5 border border-white/10 rounded-2xl p-4 space-y-2" },
+              React.createElement(
+                "p",
+                { className: "text-sm font-semibold text-white" },
+                "Lounge Playbook"
+              ),
+              React.createElement(
+                "ul",
+                { className: "list-disc list-inside text-xs text-white/70 space-y-1" },
+                menu.lounge_recommendations.map((tip, index) =>
+                  React.createElement("li", { key: `${menu.dispensary_id}-tip-${index}` }, tip)
+                )
+              )
+            )
+        );
+      };
+
+      const SocialProfileCard = ({ profile, onFindBuddies }) =>
+        React.createElement(
+          "div",
+          {
+            className:
+              "bg-white/10 border border-white/10 rounded-3xl p-5 space-y-3 backdrop-blur-xl",
+          },
+          React.createElement(
+            "div",
+            { className: "flex items-start justify-between gap-3" },
+            React.createElement(
+              "div",
+              null,
+              React.createElement(
+                "h3",
+                { className: "text-lg font-semibold text-white" },
+                profile.display_name
+              ),
+              React.createElement(
+                "p",
+                { className: "text-xs text-white/60" },
+                profile.lounge_homebase ? `Home lounge: ${profile.lounge_homebase}` : "Mobile sesher"
+              )
+            ),
+            profile.current_smoke &&
+              React.createElement(
+                "span",
+                {
+                  className:
+                    "inline-flex px-3 py-1 rounded-full text-[11px] uppercase tracking-wide bg-neon/20 text-neon border border-neon/40",
+                },
+                `Current smoke: ${profile.current_smoke}`
+              )
+          ),
+          profile.bio &&
+            React.createElement("p", { className: "text-sm text-white/70" }, profile.bio),
+          React.createElement(
+            "div",
+            { className: "flex flex-wrap gap-2 text-[10px] uppercase text-white/50" },
+            (profile.vibes || []).map((vibe) =>
+              React.createElement(
+                "span",
+                {
+                  key: `${profile.profile_id}-${vibe}`,
+                  className:
+                    "px-2 py-1 rounded-full border border-white/10 bg-white/5",
+                },
+                vibe
+              )
+            )
+          ),
+          React.createElement(
+            "p",
+            { className: "text-xs text-white/60" },
+            `Favorites: ${(profile.favorite_strains || []).join(", ")}`
+          ),
+          React.createElement(
+            "button",
+            {
+              className:
+                "inline-flex items-center justify-center px-4 py-2 rounded-full bg-white/10 border border-white/20 text-xs font-semibold uppercase tracking-wide hover:bg-white/20 transition",
+              onClick: () => onFindBuddies(profile),
+            },
+            "Find lounge buddies"
+          )
+        );
+
+      const SocialPostCard = ({ post }) =>
+        React.createElement(
+          "div",
+          {
+            className:
+              "bg-midnight/50 border border-white/10 rounded-3xl p-5 flex flex-col gap-3",
+          },
+          React.createElement(
+            "div",
+            { className: "flex items-start justify-between gap-3" },
+            React.createElement(
+              "div",
+              null,
+              React.createElement(
+                "h4",
+                { className: "text-sm font-semibold text-white" },
+                post.author_name
+              ),
+              React.createElement(
+                "p",
+                { className: "text-xs text-white/50" },
+                new Date(post.created_at).toLocaleString()
+              )
+            ),
+            post.featured_strain &&
+              React.createElement(
+                "span",
+                {
+                  className:
+                    "inline-flex px-3 py-1 rounded-full text-[11px] uppercase tracking-wide bg-haze/20 text-haze border border-haze/40",
+                },
+                post.featured_strain
+              )
+          ),
+          React.createElement("p", { className: "text-sm text-white/80" }, post.content),
+          post.media_url &&
+            React.createElement(
+              "a",
+              {
+                className: "text-xs text-neon underline",
+                href: post.media_url,
+                target: "_blank",
+                rel: "noreferrer",
+              },
+              "View drop"
+            ),
+          React.createElement(
+            "div",
+            { className: "flex items-center gap-4 text-[11px] uppercase text-white/50" },
+            React.createElement("span", null, `${post.engagement?.likes || 0} likes`),
+            React.createElement("span", null, `${post.engagement?.comments || 0} comments`)
+          ),
+          (post.vibes || []).length > 0 &&
+            React.createElement(
+              "div",
+              { className: "flex flex-wrap gap-2 text-[10px] uppercase text-white/50" },
+              post.vibes.map((vibe) =>
+                React.createElement(
+                  "span",
+                  {
+                    key: `${post.post_id}-${vibe}`,
+                    className:
+                      "px-2 py-1 rounded-full border border-white/10 bg-white/5",
+                  },
+                  vibe
+                )
+              )
+            )
+        );
+
+      const BuddyMatchesPanel = ({ matches, loungeSuggestions }) =>
+        React.createElement(
+          "div",
+          {
+            className:
+              "bg-white/5 border border-white/10 rounded-3xl p-5 space-y-3 backdrop-blur-xl",
+          },
+          React.createElement(
+            "h3",
+            { className: "text-lg font-semibold text-white" },
+            "Lounge Buddies"
+          ),
+          matches.length === 0
+            ? React.createElement(
+                "p",
+                { className: "text-sm text-white/60" },
+                "Tap a profile to surface sesh matches and shared lounges."
+              )
+            : React.createElement(
+                "ul",
+                { className: "space-y-2" },
+                matches.map((match) =>
+                  React.createElement(
+                    "li",
+                    {
+                      key: match.profile_id,
+                      className:
+                        "bg-midnight/50 border border-white/10 rounded-2xl p-4 text-sm text-white/80",
+                    },
+                    React.createElement(
+                      "p",
+                      { className: "font-semibold text-white" },
+                      match.display_name
+                    ),
+                    React.createElement(
+                      "p",
+                      { className: "text-xs text-white/60" },
+                      `Vibes: ${(match.vibes || []).join(", ")}`
+                    ),
+                    React.createElement(
+                      "p",
+                      { className: "text-xs text-white/60" },
+                      `Current smoke: ${match.current_smoke || "—"}`
+                    )
+                  )
+                )
+              ),
+          loungeSuggestions?.length > 0 &&
+            React.createElement(
+              "div",
+              { className: "text-xs text-white/70 space-y-1" },
+              React.createElement(
+                "p",
+                { className: "font-semibold text-white/80" },
+                "Suggested lounges"
+              ),
+              React.createElement(
+                "ul",
+                { className: "list-disc list-inside space-y-1" },
+                loungeSuggestions.map((lounge) =>
+                  React.createElement("li", { key: lounge }, lounge)
+                )
+              )
+            )
+        );
+
+      const ReserveModal = ({ strain, onClose }) => {
+        const [status, setStatus] = useState("idle");
+
+        useEffect(() => {
+          if (!strain) return;
+          gsap.fromTo(
+            "#reserve-card",
+            { y: 80, opacity: 0 },
+            { y: 0, opacity: 1, duration: 0.5, ease: "power3.out" }
+          );
+        }, [strain]);
+
+        const reserve = async () => {
+          setStatus("loading");
+          try {
+            const response = await fetch(`${window.BUDSENSE_API_BASE}/orders/reserve`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json", "X-Tenant-ID": "demo-shop" },
+              body: JSON.stringify({
+                tenantId: "demo-shop",
+                customer_name: "Prototype Guest",
+                contact_method: "sms",
+                contact_value: "+15555550123",
+                pickup_preference: "lounge",
+                items: [{ product_id: strain.name.toLowerCase().replace(/\s+/g, "-"), quantity: 3.5, unit: "g" }],
+              }),
+            });
+            const payload = await response.json();
+            setStatus("success");
+            setTimeout(() => onClose(), 1800);
+            return payload;
+          } catch (error) {
+            console.error(error);
+            setStatus("error");
+          }
+        };
+
+        return (
+          React.createElement(
+            "div",
+            {
+              className:
+                "fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50",
+              onClick: onClose,
+            },
+            React.createElement(
+              "div",
+              {
+                id: "reserve-card",
+                className:
+                  "w-full max-w-md bg-midnight border border-white/10 rounded-3xl p-8 shadow-2xl text-white",
+                onClick: (event) => event.stopPropagation(),
+              },
+              React.createElement(
+                "h2",
+                { className: "text-2xl font-bold mb-2" },
+                "Reserve ", strain?.name
+              ),
+              React.createElement(
+                "p",
+                { className: "text-sm text-white/70 mb-6" },
+                "We’ll ping the lounge crew and send you a confirmation via SMS."
+              ),
+              React.createElement(
+                "button",
+                {
+                  className:
+                    "w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-full bg-neon text-slate-900 font-semibold shadow-lg hover:bg-orange-400 transition",
+                  onClick: reserve,
+                  disabled: status === "loading" || status === "success",
+                },
+                status === "loading" ? "Booking your stash..." : status === "success" ? "Reserved!" : "Confirm Reserve"
+              ),
+              status === "error" &&
+                React.createElement(
+                  "p",
+                  { className: "text-sm text-rose-300 mt-4" },
+                  "Something glitched. Please try again."
+                )
+            )
+          )
+        );
+      };
+
+      const App = () => {
+        const { messages, sendUserMessage, loading: chatLoading, searchResults } = useChatbot();
+        const { menus, lastSynced, loading: menuLoading, syncMenus, applyDeals } = useMenuSync();
+        const {
+          profiles,
+          feed,
+          nextRefresh,
+          trending,
+          matches,
+          matchSummary,
+          dailyRefresh,
+          matchBuddies,
+        } = useSocialNetwork();
+        const [input, setInput] = useState("");
+        const [selectedStrain, setSelectedStrain] = useState(null);
+        const [refreshStatus, setRefreshStatus] = useState("idle");
+
+        useEffect(() => {
+          gsap.fromTo(
+            "#hero",
+            { opacity: 0, y: -20 },
+            { opacity: 1, y: 0, duration: 0.8, ease: "power3.out", delay: 0.1 }
+          );
+        }, []);
+
+        const handleDailyRefresh = async () => {
+          setRefreshStatus("loading");
+          try {
+            await dailyRefresh();
+            setRefreshStatus("success");
+            setTimeout(() => setRefreshStatus("idle"), 2000);
+          } catch (error) {
+            console.error(error);
+            setRefreshStatus("error");
+            setTimeout(() => setRefreshStatus("idle"), 2500);
+          }
+        };
+
+        const handleFindBuddies = async (profile) => {
+          await matchBuddies(profile.profile_id, profile.vibes || []);
+        };
+
+        const handleSubmit = (event) => {
+          event.preventDefault();
+          const value = input.trim();
+          if (!value) return;
+          sendUserMessage(value);
+          setInput("");
+        };
+
+        return (
+          React.createElement(
+            "main",
+            { className: "max-w-6xl mx-auto px-4 py-10 md:py-16" },
+            React.createElement(
+              "section",
+              {
+                id: "hero",
+                className:
+                  "rounded-[32px] border border-white/10 bg-white/10 backdrop-blur-xl shadow-2xl p-8 md:p-12 mb-10 flex flex-col md:flex-row md:items-center md:justify-between gap-8",
+              },
+              React.createElement(
+                "div",
+                { className: "max-w-xl" },
+                React.createElement(
+                  "h1",
+                  { className: "text-4xl md:text-5xl font-black text-white mb-4" },
+                  "BudSense.AI — Your Intelligent Budtender"
+                ),
+                React.createElement(
+                  "p",
+                  { className: "text-lg text-white/80" },
+                  "Watson-powered cannabis concierge with clean-product guardrails, lounge routing, and instant reservations."
+                ),
+                React.createElement(
+                  "div",
+                  { className: "mt-6 flex flex-wrap gap-3 text-xs uppercase tracking-wide" },
+                  ["Watson Discovery", "COA Guard", "POS Auto-Reserve", "Lounge Mode"].map((chip) =>
+                    React.createElement(
+                      "span",
+                      {
+                        key: chip,
+                        className:
+                          "px-4 py-2 rounded-full bg-midnight/80 border border-white/10 text-white/80",
+                      },
+                      chip
+                    )
+                  )
+                )
+              ),
+              React.createElement(
+                "div",
+                { className: "md:w-80 bg-midnight/60 border border-white/10 rounded-3xl p-6 shadow-xl" },
+                React.createElement(
+                  "h2",
+                  { className: "text-white font-semibold mb-4" },
+                  "Live Lounge Snapshot"
+                ),
+                React.createElement(
+                  "ul",
+                  { className: "space-y-3 text-sm text-white/70" },
+                  [
+                    "Gelato 41 — 3 tables reserved",
+                    "Zkittlez — drop alert in 2h",
+                    "Blue Dream — COA review pending",
+                  ].map((item) => React.createElement("li", { key: item }, item))
+                )
+              )
+            ),
+            React.createElement(
+              "section",
+              {
+                className:
+                  "grid grid-cols-1 lg:grid-cols-2 gap-8 items-start",
+              },
+              React.createElement(
+                "div",
+                {
+                  className:
+                    "bg-white/5 border border-white/10 rounded-[28px] p-6 md:p-8 shadow-2xl backdrop-blur-xl flex flex-col h-[520px]",
+                },
+                React.createElement(
+                  "h2",
+                  { className: "text-2xl font-bold mb-4" },
+                  "Chat with BudSense"
+                ),
+                React.createElement(
+                  "div",
+                  { className: "flex-1 overflow-y-auto pr-2 scrollbar" },
+                  messages.map((message) =>
+                    React.createElement(MessageBubble, { key: message.id, message })
+                  ),
+                  chatLoading &&
+                    React.createElement(
+                      "div",
+                      { className: "animate-pulse text-white/70 text-sm" },
+                      "Scanning lab vaults..."
+                    )
+                ),
+                React.createElement(
+                  "form",
+                  { className: "mt-4 flex gap-3", onSubmit: handleSubmit },
+                  React.createElement("input", {
+                    className:
+                      "flex-1 rounded-full bg-midnight/80 border border-white/10 px-5 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-neon/60",
+                    placeholder: "Ask for a strain, effect, or terp profile...",
+                    value: input,
+                    onChange: (event) => setInput(event.target.value),
+                  }),
+                  React.createElement(
+                    "button",
+                    {
+                      className:
+                        "px-6 py-3 rounded-full bg-neon text-slate-900 font-semibold hover:bg-orange-400 transition",
+                      type: "submit",
+                    },
+                    "Send"
+                  )
+                )
+              ),
+              React.createElement(
+                "div",
+                { className: "space-y-5" },
+                React.createElement(
+                  "div",
+                  {
+                    className:
+                      "bg-white/5 border border-white/10 rounded-[28px] p-6 md:p-8 shadow-2xl backdrop-blur-xl",
+                  },
+                  React.createElement(
+                    "h2",
+                    { className: "text-2xl font-bold text-white mb-4" },
+                    "Verified Strain Intel"
+                      ),
+                  searchResults.length === 0
+                    ? React.createElement(
+                        "p",
+                        { className: "text-sm text-white/70" },
+                        "Hit the chat to pull live strain intel, COA status, and lounge-ready reserves."
+                      )
+                    : React.createElement(
+                        "div",
+                        { className: "grid gap-4" },
+                        searchResults.map((strain) =>
+                          React.createElement(SearchCard, {
+                            key: strain.name,
+                            strain,
+                            onReserve: setSelectedStrain,
+                          })
+                        )
+                      )
+                ),
+                React.createElement(
+                  "div",
+                  {
+                    className:
+                      "bg-midnight/60 border border-white/10 rounded-[28px] p-6 md:p-8 shadow-2xl backdrop-blur-xl",
+                  },
+                  React.createElement(
+                    "h2",
+                    { className: "text-xl font-semibold text-white mb-3" },
+                    "Automation Sneak Peek"
+                  ),
+                  React.createElement(
+                    "ul",
+                    { className: "space-y-2 text-sm text-white/70" },
+                    [
+                      "Auto-order webhook feeds n8n flow",
+                      "COA ingestion flags impurities with lab link",
+                      "Notifications route through Twilio / SendGrid",
+                    ].map((item) => React.createElement("li", { key: item }, `• ${item}`))
+                      )
+                )
+              )
+            ),
+            React.createElement(
+              "section",
+              {
+                className:
+                  "mt-10 grid grid-cols-1 xl:grid-cols-2 gap-8 items-start",
+              },
+              React.createElement(
+                "div",
+                {
+                  className:
+                    "bg-white/5 border border-white/10 rounded-[28px] p-6 md:p-8 shadow-2xl backdrop-blur-xl space-y-5",
+                },
+                React.createElement(
+                  "div",
+                  { className: "flex items-center justify-between gap-4" },
+                  React.createElement(
+                    "div",
+                    null,
+                    React.createElement(
+                      "h2",
+                      { className: "text-2xl font-bold text-white" },
+                      "Live menus within 60 miles"
+                    ),
+                    React.createElement(
+                      "p",
+                      { className: "text-sm text-white/70" },
+                      lastSynced
+                        ? `Synced ${new Date(lastSynced).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+                        : "Pulling drop intel from partner menus..."
+                    )
+                  ),
+                  React.createElement(
+                    "button",
+                    {
+                      className:
+                        "inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/10 border border-white/20 text-xs font-semibold uppercase tracking-wide hover:bg-white/15 transition",
+                      onClick: () => syncMenus(60),
+                      disabled: menuLoading,
+                    },
+                    menuLoading ? "Refreshing..." : "Sync menus"
+                  )
+                ),
+                menuLoading &&
+                  React.createElement(
+                    "p",
+                    { className: "text-sm text-white/60" },
+                    "Syncing verified dispensary menus..."
+                  ),
+                !menuLoading && menus.length === 0 &&
+                  React.createElement(
+                    "p",
+                    { className: "text-sm text-white/60" },
+                    "No menus found yet. Tap refresh to pull the latest."
+                  ),
+                React.createElement(
+                  "div",
+                  { className: "space-y-5" },
+                  menus.map((menu) =>
+                    React.createElement(MenuCard, {
+                      key: menu.dispensary_id,
+                      menu,
+                      onApplyDeals: applyDeals,
+                    })
+                  )
+                )
+              ),
+              React.createElement(
+                "div",
+                { className: "space-y-6" },
+                React.createElement(
+                  "div",
+                  {
+                    className:
+                      "bg-white/5 border border-white/10 rounded-[28px] p-6 md:p-8 shadow-2xl backdrop-blur-xl space-y-5",
+                  },
+                  React.createElement(
+                    "div",
+                    { className: "flex items-center justify-between gap-4" },
+                    React.createElement(
+                      "div",
+                      null,
+                      React.createElement(
+                        "h2",
+                        { className: "text-2xl font-bold text-white" },
+                        "Lounge buddies social"
+                      ),
+                      React.createElement(
+                        "p",
+                        { className: "text-xs uppercase tracking-wide text-white/50" },
+                        nextRefresh
+                          ? `Next refresh by ${new Date(nextRefresh).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+                          : "Daily drop engine warming up"
+                      )
+                    ),
+                    React.createElement(
+                      "button",
+                      {
+                        className:
+                          "inline-flex items-center gap-2 px-4 py-2 rounded-full bg-neon text-slate-900 font-semibold hover:bg-orange-400 transition disabled:opacity-70",
+                        onClick: handleDailyRefresh,
+                        disabled: refreshStatus === "loading",
+                      },
+                      refreshStatus === "loading"
+                        ? "Refreshing..."
+                        : refreshStatus === "success"
+                        ? "Social synced"
+                        : "Daily refresh"
+                    )
+                  ),
+                  trending.length > 0 &&
+                    React.createElement(
+                      "div",
+                      { className: "flex flex-wrap gap-2 text-[10px] uppercase text-white/50" },
+                      trending.map((tag) =>
+                        React.createElement(
+                          "span",
+                          {
+                            key: tag,
+                            className:
+                              "px-3 py-1 rounded-full border border-white/10 bg-white/5",
+                          },
+                          tag
+                        )
+                      )
+                    ),
+                  React.createElement(
+                    "div",
+                    { className: "space-y-4" },
+                    feed.map((post) =>
+                      React.createElement(SocialPostCard, { key: post.post_id, post })
+                    )
+                  )
+                ),
+                React.createElement(
+                  "div",
+                  {
+                    className:
+                      "bg-white/5 border border-white/10 rounded-[28px] p-6 md:p-8 shadow-2xl backdrop-blur-xl space-y-5",
+                  },
+                  React.createElement(
+                    "h2",
+                    { className: "text-xl font-bold text-white" },
+                    "Profiles nearby"
+                  ),
+                  React.createElement(
+                    "div",
+                    { className: "grid gap-4" },
+                    profiles.map((profile) =>
+                      React.createElement(SocialProfileCard, {
+                        key: profile.profile_id,
+                        profile,
+                        onFindBuddies: handleFindBuddies,
+                      })
+                    )
+                  ),
+                  React.createElement(BuddyMatchesPanel, {
+                    matches,
+                    loungeSuggestions: matchSummary.loungeSuggestions,
+                  })
+                )
+              )
+            ),
+            selectedStrain &&
+              React.createElement(ReserveModal, {
+                strain: selectedStrain,
+                onClose: () => setSelectedStrain(null),
+              })
+          )
+        );
+      };
+
+      const root = ReactDOM.createRoot(document.getElementById("root"));
+      root.render(React.createElement(App));
+    </script>
+  </body>
+</html>

--- a/n8n/flows/auto_order.json
+++ b/n8n/flows/auto_order.json
@@ -1,0 +1,199 @@
+{
+  "name": "BudSense Auto-Reserve",
+  "nodes": [
+    {
+      "parameters": {
+        "path": "budsense/reserve",
+        "options": {}
+      },
+      "id": "Webhook_Entry",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "predefinedCredentialType",
+        "url": "={{$json[\"apiBase\"] || 'http://backend:8000/orders/reserve'}}",
+        "options": {},
+        "sendBody": true,
+        "jsonParameters": true,
+        "options": {
+          "bodyContentType": "json"
+        }
+      },
+      "id": "Reserve_Order",
+      "name": "Reserve Order",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 2,
+      "position": [
+        520,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "fromEmail": "reservations@budsense.ai",
+        "toEmail": "={{$json[\"customerEmail\"]}}",
+        "subject": "BudSense.AI Reservation",
+        "text": "Your stash is locked and clean-certified. Show this email when you arrive!",
+        "options": {}
+      },
+      "id": "Send_Email",
+      "name": "Send Email",
+      "type": "n8n-nodes-base.sendEmail",
+      "typeVersion": 2,
+      "position": [
+        820,
+        220
+      ]
+    },
+    {
+      "parameters": {
+        "from": "+15555550123",
+        "to": "={{$json[\"customerPhone\"]}}",
+        "message": "BudSense.AI: Your reserve is confirmed. Tap the link to pick up when ready!"
+      },
+      "id": "Send_SMS",
+      "name": "Send SMS",
+      "type": "n8n-nodes-base.twilio",
+      "typeVersion": 1,
+      "position": [
+        820,
+        380
+      ]
+    },
+    {
+      "parameters": {
+        "triggerTimes": [
+          {
+            "hour": 9,
+            "minute": 0
+          }
+        ],
+        "mode": "everyDay"
+      },
+      "id": "Daily_Schedule",
+      "name": "Daily Schedule",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [
+        250,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "predefinedCredentialType",
+        "url": "={{$json[\"apiBase\"] || 'http://backend:8000/menus/sync'}}",
+        "options": {},
+        "method": "POST",
+        "sendBody": true,
+        "jsonParameters": true,
+        "options": {
+          "bodyContentType": "json"
+        },
+        "bodyParametersJson": "{\n  \"location\": {\n    \"lat\": 37.7749,\n    \"lon\": -122.4194\n  },\n  \"radius_miles\": 60\n}"
+      },
+      "id": "Sync_Menus",
+      "name": "Sync Menus",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 2,
+      "position": [
+        520,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "predefinedCredentialType",
+        "url": "={{$json[\"apiBase\"] || 'http://backend:8000/social/daily-refresh'}}",
+        "options": {},
+        "method": "POST",
+        "sendBody": true,
+        "jsonParameters": true,
+        "options": {
+          "bodyContentType": "json"
+        },
+        "bodyParametersJson": "{\n  \"highlight_strains\": [\n    \"Gelato 41\",\n    \"Zkittlez\"\n  ]\n}"
+      },
+      "id": "Refresh_Social",
+      "name": "Refresh Social",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 2,
+      "position": [
+        820,
+        40
+      ]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Reserve Order",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Daily Schedule": {
+      "main": [
+        [
+          {
+            "node": "Sync Menus",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Sync Menus": {
+      "main": [
+        [
+          {
+            "node": "Refresh Social",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Reserve Order": {
+      "main": [
+        [
+          {
+            "node": "Send Email",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Send SMS",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "saveExecutionProgress": "DEFAULT",
+    "saveManualExecutions": true
+  },
+  "pinData": {},
+  "tags": [
+    {
+      "id": "BudSense",
+      "name": "BudSense"
+    }
+  ],
+  "id": "BudSenseAutoReserve",
+  "active": false,
+  "versionId": "1"
+}


### PR DESCRIPTION
## Summary
- extend the FastAPI prototype with live dispensary menu syncing, deal application, and lounge social graph endpoints
- expand the React demo to showcase menu downloads, lounge deal pairing, and the daily lounge buddies feed with matching
- document the new capabilities, environment variables, and automation updates for menu sweeps and social refreshes

## Testing
- python -m compileall backend/app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139a15eaf8832c960182bc7447ba23)